### PR TITLE
Migrating from master-slave phrasing

### DIFF
--- a/apps/cmdb/migrations/0001_initial.py
+++ b/apps/cmdb/migrations/0001_initial.py
@@ -130,7 +130,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100, verbose_name='服务名称')),
                 ('version', models.CharField(blank=True, max_length=100, verbose_name='服务版本')),
                 ('service_type', models.SmallIntegerField(blank=True, choices=[(0, '消息队列'), (1, '数据库'), (2, '中间件')], default=0, verbose_name='服务类型')),
-                ('cluster_type', models.CharField(blank=True, choices=[('standlone', '单机模式'), ('master-slave', '主从模式'), ('cluster', '高可用模式')], default='standlone', max_length=50, verbose_name='集群模式')),
+                ('cluster_type', models.CharField(blank=True, choices=[('standlone', '单机模式'), ('main-subordinate', '主从模式'), ('cluster', '高可用模式')], default='standlone', max_length=50, verbose_name='集群模式')),
                 ('remark', models.TextField(blank=True, null=True, verbose_name='备注')),
                 ('server', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='server', to='cmdb.Server', verbose_name='部署主机')),
             ],

--- a/apps/cmdb/models.py
+++ b/apps/cmdb/models.py
@@ -139,7 +139,7 @@ class Service(models.Model):
     )
     cluster_chioce = (
         ("standlone", "单机模式"),
-        ("master-slave", "主从模式"),
+        ("main-subordinate", "主从模式"),
         ("cluster", "高可用模式"),
     )
     name = models.CharField(verbose_name="服务名称", max_length=100)

--- a/static/adminlet-2.4.10/bower_components/bootstrap-datepicker/docs/conf.py
+++ b/static/adminlet-2.4.10/bower_components/bootstrap-datepicker/docs/conf.py
@@ -49,8 +49,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'bootstrap-datepicker'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.